### PR TITLE
Remove persistence resource parsing conversion

### DIFF
--- a/jenkins/osa_onmetal.functions.groovy
+++ b/jenkins/osa_onmetal.functions.groovy
@@ -408,11 +408,6 @@ def parse_persistent_resources_tests(){
 
     sh """
     ssh -o StrictHostKeyChecking=no root@${host_ip} '''
-    
-    for f in /root/subunit/persistent_resources/*
-    do 
-        cat \$f|subunit-1to2|subunit2csv > \$f.csv
-    done
     cd /root/subunit/persistent_resources/
     resource-parse --u . > /root/output/persistent_resource.txt
     rm *.csv


### PR DESCRIPTION
Removed subunit conversion from groovy, because subunit to csv has been added to parsing script.